### PR TITLE
Update DelimitedReader.java

### DIFF
--- a/src/main/java/coffeepot/bean/wr/reader/DelimitedReader.java
+++ b/src/main/java/coffeepot/bean/wr/reader/DelimitedReader.java
@@ -155,7 +155,7 @@ public class DelimitedReader extends AbstractReader {
             }
         }
 
-        String[] values = line.split(regexSplit);
+        String[] values = line.split(regexSplit,-1);
 
         if (escape != null) {
             for (int i = 0; i < values.length; i++) {


### PR DESCRIPTION
Changed the call to String.split method in getNextRecord(BufferedReader) method to include a negative calling limit parameter. This way it will not ignore trailing empty fields.
